### PR TITLE
use the slim python image to reduce the image size

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # base-image for python on any machine using a template variable,
 # see more about dockerfile templates here:http://docs.resin.io/pages/deployment/docker-templates
-FROM resin/%%RESIN_MACHINE_NAME%%-python:3.6
+FROM resin/%%RESIN_MACHINE_NAME%%-python:3-slim
 
 # Set our working directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
It should have everything needed for this small server.

I see <200MB image afterwards, and >400MB before.