### PR TITLE
Added cast to integer for port parameter which gets loaded as a string

### DIFF
--- a/Pycom/1.0.0/flash/lib/OTA.py
+++ b/Pycom/1.0.0/flash/lib/OTA.py
@@ -149,7 +149,7 @@ class WiFiOTA(OTA):
         self.SSID = ssid
         self.password = password
         self.ip = ip
-        self.port = port
+        self.port = int(port)
 
     def connect(self):
         self.wlan = network.WLAN(mode=network.WLAN.STA)

--- a/Pycom/1.0.1/flash/lib/OTA.py
+++ b/Pycom/1.0.1/flash/lib/OTA.py
@@ -149,7 +149,7 @@ class WiFiOTA(OTA):
         self.SSID = ssid
         self.password = password
         self.ip = ip
-        self.port = port
+        self.port = int(port)
 
     def connect(self):
         self.wlan = network.WLAN(mode=network.WLAN.STA)


### PR DESCRIPTION
While testing this repo on a Pycom SyPy I got a type mismatch exception since the port parameter would be loaded from config.py as a string.
Adding this cast fixed the problem but maybe it was a Resin configuration error that caused it.